### PR TITLE
fix GTK error: t->tbe.proxy is a GtkLabel

### DIFF
--- a/xombrero.c
+++ b/xombrero.c
@@ -7603,8 +7603,8 @@ statusbar_create(struct tab *t)
 				gtk_box_pack_start(b, t->sbe.proxy, FALSE,
 				    FALSE, 0);
 				if (proxy_uri)
-					gtk_entry_set_text(
-					    GTK_ENTRY(t->sbe.proxy), "proxy");
+					gtk_label_set_text(
+					    GTK_LABEL(t->sbe.proxy), "proxy");
 			}
 			break;
 		default:


### PR DESCRIPTION
This gets rid of a gtk error message, which interfered with properly displaying the proxy state on the statusbar.
