### PR TITLE
Define XT_DS_RESOURCE_DIR in the Linux Makefile.

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -25,6 +25,7 @@ BINDIR?= $(PREFIX)/bin
 APPDIR?= $(PREFIX)/share/applications
 MANDIR?= $(PREFIX)/share/man
 RESDIR?= $(PREFIX)/share/xombrero
+CFLAGS+= -DXT_DS_RESOURCE_DIR=\"$(RESDIR)\"
 
 SRCS= $(shell ls ../*.c)
 SRCS+= linux.c

--- a/xombrero.h
+++ b/xombrero.h
@@ -689,7 +689,6 @@ int		command_mode(struct tab *, struct karg *);
 #define XT_DS_ALLOW_INSECURE_CONTENT	(TRUE)
 #define XT_DS_ALLOW_INSECURE_SCRIPTS	(TRUE)
 #define XT_DS_WARN_CERT_CHANGES	(0)
-#define XT_DS_RESOURCE_DIR	("/usr/local/share/xombrero")
 #define XT_DS_DO_NOT_TRACK	(0)
 #define XT_DS_PRELOAD_STRICT_TRANSPORT	(1)
 #define XT_DS_GNUTLS_PRIORITY_STRING	(NULL)


### PR DESCRIPTION
XT_DS_RESOURCE_DIR was hard-coded to /usr/local/share/xombrero.  If a
user ran make with a custom PREFIX, XT_DS_RESOURCE_DIR was not accurate.

Note: the change has only been made to the Linux Makefile.  I'll happily add the change to the other Makefiles but would like some feedback first as I'm not very familiar with xombrero's structure and policies.
