### PR TITLE
explained a variable with a comment, changed bindings so that all toggle...

### DIFF
--- a/settings.c
+++ b/settings.c
@@ -1459,23 +1459,24 @@ walk_mime_type(struct settings *s,
 
 /* inherent to GTK not all keys will be caught at all times */
 /* XXX sort key bindings */
+/* command, mod, binding available in insert mode, key */
 struct key_binding	keys[] = {
 	{ "command_mode",	0,	1,	GDK_Escape	},
 	{ "insert_mode",	0,	0,	GDK_i		},
-	{ "cookiejar",		MOD1,	1,	GDK_j		},
+	{ "cookiejar",		CTRL,	1,	GDK_j		},
 	{ "downloadmgr",	MOD1,	1,	GDK_d		},
 	{ "history",		MOD1,	1,	GDK_h		},
 	{ "print",		CTRL,	1,	GDK_p		},
 	{ "search",		0,	0,	GDK_slash	},
 	{ "searchb",		0,	0,	GDK_question	},
-	{ "statustoggle",	CTRL,	1,	GDK_n		},
+	{ "statustoggle",	MOD1,	1,	GDK_n		},
 	{ "command",		0,	0,	GDK_colon	},
 	{ "qa",			CTRL,	1,	GDK_q		},
 	{ "restart",		MOD1,	1,	GDK_q		},
-	{ "js toggle",		CTRL,	1,	GDK_j		},
+	{ "js toggle",		MOD1,	1,	GDK_j		},
 	{ "plugin toggle",	MOD1,	1,	GDK_p		},
 	{ "cookie toggle",	MOD1,	1,	GDK_c		},
-	{ "togglesrc",		CTRL,	1,	GDK_s		},
+	{ "togglesrc",		MOD1,	1,	GDK_s		},
 	{ "yankuri",		0,	0,	GDK_y		},
 	{ "pasteuricur",	0,	0,	GDK_p		},
 	{ "pasteurinew",	0,	0,	GDK_P		},

--- a/xombrero.c
+++ b/xombrero.c
@@ -5687,7 +5687,7 @@ struct buffercmd {
 	{ "^go[a-zA-Z0-9]$",	XT_PRE_NO,	"go",	qmark,		XT_QMARK_OPEN },
 	{ "^gn[a-zA-Z0-9]$",	XT_PRE_NO,	"gn",	qmark,		XT_QMARK_TAB },
 	{ "^ZR$",		XT_PRE_NO,	"ZR",	restart,	0 },
-	{ "^ZZ$",		XT_PRE_NO,	"ZZ",	quit,		0 },
+	{ "^ZZ$",		XT_PRE_NO,	"ZZ",	save_tabs_and_quit,		0 },
 	{ "^zi$",		XT_PRE_NO,	"zi",	resizetab,	XT_ZOOM_IN },
 	{ "^zo$",		XT_PRE_NO,	"zo",	resizetab,	XT_ZOOM_OUT },
 	{ "^z0$",		XT_PRE_NO,	"z0",	resizetab,	XT_ZOOM_NORMAL },


### PR DESCRIPTION
...s are consistently bound with MOD1, made _C_ookie _J_ar C-j

C-j - cookie jar, how did you miss that? :P

I'd personally change the vast majority of the bindings- because you're only half committed to the vi modal binding system. Many of the bindings are emacs like (using ctrl/mod/etc) and aren't modal. However I thought I'd just start off with something small.

The 3rd item in the key_binding structure was undocumented, but I managed to figure it out, and I thought it'd be nice to have a comment there explaining what it does. The config-based bindings are not robust enough to change much, so settings.c is a valuable resource. It's simple enough that you don't need to know C to configure xombrero at the source- I think this should be made more apparent on the wiki as well.