### PR TITLE
fix for gtk-warning

### DIFF
--- a/xombrero.css
+++ b/xombrero.css
@@ -25,8 +25,8 @@
 
 * {
 	border-width: 1px;
-	padding: 1;
-	margin: 1;
+	padding: 1px;
+	margin: 1px;
 	-GtkScrolledWindow-scrollbar-spacing: 1;
 	-GtkWidget-line-width: 1;
 }


### PR DESCRIPTION
(xombrero:3116): Gtk-WARNING **: Theme parsing error: xombrero.css:28:11: Not using units is deprecated. Assuming 'px'.
(xombrero:3116): Gtk-WARNING **: Theme parsing error: xombrero.css:29:10: Not using units is deprecated. Assuming 'px'.