### PR TITLE
Complete favourites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.rej.orig
 *~
 *.swp
+.exrc
 javascript.h
 xombrero
 xombrero.cat1

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.rej
 *.rej.orig
 *~
+*.swp
 javascript.h
 xombrero
 xombrero.cat1

--- a/about.c
+++ b/about.c
@@ -641,7 +641,6 @@ add_favorite(struct tab *t, struct karg *args)
 }
 
 /* read a legacy favorites from an open FILE*
-
 (we don't write these any more)
 */
 static int
@@ -710,9 +709,8 @@ restore_favorites(void)
 		return retval;
 
 	} else {
-	/* TODO: when we can reasonable assume all favourites files
-		are updated, remove everything in here but this: */
-
+	/* TODO: when we can reasonably assume all favourites files
+	are updated, remove everything in here but this: */
 		/* file seems to start with URL, use new-style code */
 		fclose(f);
 		return load_pagelist_from_disk(&favs, XT_FAVS_FILE);

--- a/about.c
+++ b/about.c
@@ -562,27 +562,15 @@ xtp_handle_dl(struct tab *t, uint8_t cmd, int id, const char *query)
 void
 xtp_handle_hl(struct tab *t, uint8_t cmd, int id, const char *query)
 {
-	struct pagelist_entry		*h, *next, *ht;
-	int			i = 1;
+	struct pagelist_entry	*h, *ht;
 
 	switch (cmd) {
 	case XT_XTP_HL_REMOVE:
-		/* walk backwards, as listed in reverse */
-		for (h = RB_MAX(history_list, &hl); h != NULL; h = next) {
-			next = RB_PREV(history_list, &hl, h);
-			if (id == i) {
-				RB_REMOVE(history_list, &hl, h);
-				g_free((gpointer) h->title);
-				g_free((gpointer) h->uri);
-				g_free(h);
-				break;
-			}
-			i++;
-		}
+		remove_pagelist_entry_by_count(&hl, 1);
 		break;
 	case XT_XTP_HL_REMOVE_ALL:
-		RB_FOREACH_SAFE(h, history_list, &hl, ht)
-			RB_REMOVE(history_list, &hl, h);
+		RB_FOREACH_SAFE(h, pagelist, &hl, ht)
+			remove_pagelist_entry(&hl, h);
 		break;
 	case XT_XTP_HL_LIST:
 		/* Nothing - just xtp_page_hl() below */
@@ -1672,7 +1660,7 @@ xtp_page_hl(struct tab *t, struct karg *args)
 	    "<th style='width: 40px'>Rm</th></tr>\n",
 	    XT_XTP_STR, XT_XTP_HL, t->session_key, XT_XTP_HL_REMOVE_ALL);
 
-	RB_FOREACH_REVERSE(h, history_list, &hl) {
+	RB_FOREACH_REVERSE(h, pagelist, &hl) {
 		tmp = body;
 		body = g_strdup_printf(
 		    "%s\n<tr>"

--- a/about.c
+++ b/about.c
@@ -583,95 +583,31 @@ xtp_handle_hl(struct tab *t, uint8_t cmd, int id, const char *query)
 	xtp_page_hl(t, NULL);
 }
 
-/* remove a favorite */
 void
 remove_favorite(struct tab *t, int index)
 {
-	char			file[PATH_MAX], *title, *uri = NULL;
-	char			*new_favs, *tmp;
-	FILE			*f;
-	int			i;
-	size_t			len, lineno;
-
-	/* open favorites */
-	snprintf(file, sizeof file, "%s" PS "%s", work_dir, XT_FAVS_FILE);
-
-	if ((f = fopen(file, "r")) == NULL) {
-		show_oops(t, "%s: can't open favorites: %s",
-		    __func__, strerror(errno));
+	/* Load before manipulation in case other processes have changed
+	the file beneath us */
+	if (restore_favorites()) {
+		show_oops(t, "Error reading favorites file: %s",
+		    strerror(errno));
 		return;
 	}
+	
+	remove_pagelist_entry_by_count(&favs, index);
 
-	/* build a string which will become the new favorites file */
-	new_favs = g_strdup("");
-
-	for (i = 1;;) {
-		if ((title = fparseln(f, &len, &lineno, NULL, 0)) == NULL)
-			if (feof(f) || ferror(f))
-				break;
-		/* XXX THIS IS NOT THE RIGHT HEURISTIC */
-		if (len == 0) {
-			free(title);
-			title = NULL;
-			continue;
-		}
-
-		if ((uri = fparseln(f, &len, &lineno, NULL, 0)) == NULL) {
-			if (feof(f) || ferror(f)) {
-				show_oops(t, "%s: can't parse favorites %s",
-				    __func__, strerror(errno));
-				goto clean;
-			}
-		}
-
-		/* as long as this isn't the one we are deleting add to file */
-		if (i != index) {
-			tmp = new_favs;
-			new_favs = g_strdup_printf("%s%s\n%s\n",
-			    new_favs, title, uri);
-			g_free(tmp);
-		}
-
-		free(uri);
-		uri = NULL;
-		free(title);
-		title = NULL;
-		i++;
-	}
-	fclose(f);
-
-	/* write back new favorites file */
-	if ((f = fopen(file, "w")) == NULL) {
-		show_oops(t, "%s: can't open favorites: %s",
-		    __func__, strerror(errno));
-		goto clean;
+	if (save_pagelist_to_disk(&favs, XT_FAVS_FILE)) {
+		update_favorite_tabs(NULL);
 	}
 
-	if (fwrite(new_favs, strlen(new_favs), 1, f) != 1)
-		show_oops(t, "%s: can't fwrite", __func__);
-	fclose(f);
-
-clean:
-	if (uri)
-		free(uri);
-	if (title)
-		free(title);
-
-	g_free(new_favs);
 }
 
 int
 add_favorite(struct tab *t, struct karg *args)
 {
-	char			file[PATH_MAX];
-	FILE			*f;
-	char			*line = NULL;
-	size_t			urilen, linelen;
-	gchar			*argtitle = NULL;
 	const gchar		*uri, *title;
-
-	if (t == NULL)
-		return (1);
+	gchar			*argtitle = NULL;
+	int 			retval;
 
 	/* don't allow adding of xtp pages to favorites */
 	if (t->xtp_meaning != XT_XTP_TAB_MEANING_NORMAL) {
@@ -679,55 +615,110 @@ add_favorite(struct tab *t, struct karg *args)
 		return (1);
 	}
 
-	snprintf(file, sizeof file, "%s" PS "%s", work_dir, XT_FAVS_FILE);
-	if ((f = fopen(file, "r+")) == NULL) {
-		show_oops(t, "Can't open favorites file: %s", strerror(errno));
-		return (1);
+	/* Load before manipulation in case other processes have changed
+	the file beneath us */
+	if (restore_favorites()) {
+		show_oops(t, "Error reading favorites file: %s",
+		    strerror(errno));
+		return 1;
 	}
 
 	if (args->s && strlen(g_strstrip(args->s)))
 		argtitle = html_escape(g_strstrip(args->s));
-
+	
 	title = argtitle ? argtitle : get_title(t, FALSE);
 	uri = get_uri(t);
+	insert_pagelist_entry(&favs, uri, title, 0);
 
-	if (title == NULL || uri == NULL) {
-		show_oops(t, "can't add page to favorites");
-		goto done;
+	if ((retval = save_pagelist_to_disk(&favs, XT_FAVS_FILE))) {
+
+		update_favorite_tabs(NULL);
 	}
+	if (argtitle) 
+		g_free(argtitle);
 
-	urilen = strlen(uri);
+	return (retval);
+}
 
-	for (;;) {
-		if ((line = fparseln(f, &linelen, NULL, NULL, 0)) == NULL) {
-			if (feof(f))
+/* read a legacy favorites from an open FILE*
+
+(we don't write these any more)
+*/
+static int
+load_legacy_favorites(FILE *f)
+{
+	char                    *uri = NULL, *title = NULL;
+	size_t                  len, lineno;
+	int                     failed = 0;
+	const char              delim[3] = {'\\', '\\', '\0'};
+
+	for (lineno = 1;;) {
+		if ((title = fparseln(f, &len, &lineno, delim, 0)) == NULL)
+			break;
+		if (strlen(title) == 0) {
+			free(title);
+			title = NULL;
+			continue;
+		}
+
+		if ((uri = fparseln(f, &len, &lineno, delim, 0)) == NULL) {
+			if (feof(f) || ferror(f)) {
+				failed = 1;
 				break;
-			else {
-				show_oops(t, "Error reading favorites file: %s",
-				    strerror(errno));
-				goto done;
 			}
 		}
 
-		if (linelen == urilen && !strcmp(line, uri))
-			goto done;
+		insert_pagelist_entry(&favs, uri, title, 0);
+		free(title);
+		free(uri);
+		lineno += 1;
+	}
+	return failed;
+}
 
-		free(line);
-		line = NULL;
+/* Pull the list of favorites into memory.  
+
+This supports loading old-style favorite lists (title/url) in addition
+to the new standard pagelist format.
+*/
+int
+restore_favorites(void)
+{
+	char                    file[PATH_MAX], magic[5];
+	FILE			*f;
+
+	empty_pagelist(&favs);
+
+	/* heuristic: new-style favourites should start with a http url
+	   if our favorites file doesn't, assume it's old style */
+	snprintf(file, sizeof file, "%s" PS "%s", work_dir, XT_FAVS_FILE);
+	if ((f = fopen(file, "r")) == NULL) {
+		warnx("%s: fopen", __func__);
+		return (1);
 	}
 
-	fprintf(f, "\n%s\n%s", title, uri);
-done:
-	if (argtitle)
-		g_free(argtitle);
-	if (line)
-		free(line);
-	fclose(f);
+	magic[4] = 0;
+	if (4==fread(magic, 1, 4, f)
+			&& strcmp(magic, "http")) {
+		/* doesn't start with http, try old-style favorite parsing */
+		int retval;
 
-	update_favorite_tabs(NULL);
+		warnx("Warning: Suspecting old-style favorites file.");
+		rewind(f);
+		retval = load_legacy_favorites(f);
+		fclose(f);
+		return retval;
 
-	return (0);
+	} else {
+	/* TODO: when we can reasonable assume all favourites files
+		are updated, remove everything in here but this: */
+
+		/* file seems to start with URL, use new-style code */
+		fclose(f);
+		return load_pagelist_from_disk(&favs, XT_FAVS_FILE);
+	}
 }
+
 
 char *
 search_engine_add(char *body, const char *name, const char *url,
@@ -1279,13 +1270,9 @@ xtp_page_ab(struct tab *t, struct karg *args)
 int
 xtp_page_fl(struct tab *t, struct karg *args)
 {
-	char			file[PATH_MAX];
-	FILE			*f;
-	char			*uri = NULL, *title = NULL;
-	size_t			len, lineno = 0;
-	int			i, failed = 0;
+	int			row = 0, failed = 0;
 	char			*body, *tmp, *page = NULL;
-	const char		delim[3] = {'\\', '\\', '\0'};
+	struct pagelist_entry	*item;
 
 	DNPRINTF(XT_D_FAVORITE, "%s:", __func__);
 
@@ -1296,13 +1283,6 @@ xtp_page_fl(struct tab *t, struct karg *args)
 
 	generate_xtp_session_key(&t->session_key);
 
-	/* open favorites */
-	snprintf(file, sizeof file, "%s" PS "%s", work_dir, XT_FAVS_FILE);
-	if ((f = fopen(file, "r")) == NULL) {
-		show_oops(t, "Can't open favorites file: %s", strerror(errno));
-		return (1);
-	}
-
 	/* body */
 	if (args && args->i & XT_DELETE)
 		body = g_strdup_printf("<table style='table-layout:fixed'><tr>"
@@ -1312,22 +1292,7 @@ xtp_page_fl(struct tab *t, struct karg *args)
 		body = g_strdup_printf("<table style='table-layout:fixed'><tr>"
 		    "<th style='width: 40px'>&#35;</th><th>Link</th></tr>\n");
 
-	for (i = 1;;) {
-		if ((title = fparseln(f, &len, &lineno, delim, 0)) == NULL)
-			break;
-		if (strlen(title) == 0) {
-			free(title);
-			title = NULL;
-			continue;
-		}
-
-		if ((uri = fparseln(f, &len, &lineno, delim, 0)) == NULL)
-			if (feof(f) || ferror(f)) {
-				show_oops(t, "favorites file corrupt");
-				failed = 1;
-				break;
-			}
-
+	RB_FOREACH_REVERSE(item, pagelist, &favs) {
 		tmp = body;
 		if (args && args->i & XT_DELETE)
 			body = g_strdup_printf("%s<tr>"
@@ -1336,28 +1301,23 @@ xtp_page_fl(struct tab *t, struct karg *args)
 			    "<td style='text-align: center'>"
 			    "<a href='%s%d/%s/%d/%d'>X</a></td>"
 			    "</tr>\n",
-			    body, i, uri, title,
+			    body, row, item->uri, item->title,
 			    XT_XTP_STR, XT_XTP_FL,
 			    t->session_key ? t->session_key : "",
-			    XT_XTP_FL_REMOVE, i);
+			    XT_XTP_FL_REMOVE, row);
 		else
 			body = g_strdup_printf("%s<tr>"
 			    "<td>%d</td>"
 			    "<td><a href='%s'>%s</a></td>"
 			    "</tr>\n",
-			    body, i, uri, title);
+			    body, row, item->uri, item->title);
 		g_free(tmp);
 
-		free(uri);
-		uri = NULL;
-		free(title);
-		title = NULL;
-		i++;
+		row++;
 	}
-	fclose(f);
 
 	/* if none, say so */
-	if (i == 1) {
+	if (row == 1) {
 		tmp = body;
 		body = g_strdup_printf("%s<tr>"
 		    "<td colspan='%d' style='text-align: center'>"
@@ -1369,11 +1329,6 @@ xtp_page_fl(struct tab *t, struct karg *args)
 	tmp = body;
 	body = g_strdup_printf("%s</table>", body);
 	g_free(tmp);
-
-	if (uri)
-		free(uri);
-	if (title)
-		free(title);
 
 	/* render */
 	if (!failed) {

--- a/about.c
+++ b/about.c
@@ -562,7 +562,7 @@ xtp_handle_dl(struct tab *t, uint8_t cmd, int id, const char *query)
 void
 xtp_handle_hl(struct tab *t, uint8_t cmd, int id, const char *query)
 {
-	struct history		*h, *next, *ht;
+	struct pagelist_entry		*h, *next, *ht;
 	int			i = 1;
 
 	switch (cmd) {
@@ -1652,7 +1652,7 @@ int
 xtp_page_hl(struct tab *t, struct karg *args)
 {
 	char			*body, *page, *tmp;
-	struct history		*h;
+	struct pagelist_entry		*h;
 	int			i = 1; /* all ids start 1 */
 
 	DNPRINTF(XT_D_CMD, "%s", __func__);

--- a/about.c
+++ b/about.c
@@ -599,7 +599,8 @@ remove_favorite(struct tab *t, int index)
 	if (save_pagelist_to_disk(&favs, XT_FAVS_FILE)) {
 		update_favorite_tabs(NULL);
 	}
-
+	/* TODO: We should remove the URI from the list of completions here,
+	too */
 }
 
 int
@@ -629,6 +630,7 @@ add_favorite(struct tab *t, struct karg *args)
 	title = argtitle ? argtitle : get_title(t, FALSE);
 	uri = get_uri(t);
 	insert_pagelist_entry(&favs, uri, title, 0);
+	completion_add_uri(uri);
 
 	if ((retval = save_pagelist_to_disk(&favs, XT_FAVS_FILE))) {
 
@@ -683,7 +685,8 @@ to the new standard pagelist format.
 int
 restore_favorites(void)
 {
-	char                    file[PATH_MAX], magic[5];
+	int			retval;
+	char                    file[PATH_MAX], magic[4];
 	FILE			*f;
 
 	empty_pagelist(&favs);
@@ -696,25 +699,24 @@ restore_favorites(void)
 		return (1);
 	}
 
-	magic[4] = 0;
 	if (4==fread(magic, 1, 4, f)
-			&& strcmp(magic, "http")) {
+			&& strncmp(magic, "http", 4)) {
 		/* doesn't start with http, try old-style favorite parsing */
-		int retval;
 
 		warnx("Warning: Suspecting old-style favorites file.");
 		rewind(f);
 		retval = load_legacy_favorites(f);
 		fclose(f);
-		return retval;
 
 	} else {
 	/* TODO: when we can reasonably assume all favourites files
-	are updated, remove everything in here but this: */
+		are updated, remove everything in here but this: */
 		/* file seems to start with URL, use new-style code */
 		fclose(f);
-		return load_pagelist_from_disk(&favs, XT_FAVS_FILE);
+		retval = load_pagelist_from_disk(&favs, XT_FAVS_FILE);
 	}
+	
+	return retval;
 }
 
 

--- a/history.c
+++ b/history.c
@@ -19,6 +19,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/* This module contains generic code for lists of web pages, as well
+as special handling for history and favorites. */
+
+
 #include <xombrero.h>
 
 #define XT_HISTORY_FILE		("history")
@@ -31,7 +35,7 @@
 int
 purge_history(void)
 {
-	struct history		*h, *next;
+	struct pagelist_entry		*h, *next;
 	double			age = 0.0;
 
 	DNPRINTF(XT_D_HISTORY, "%s: hl_purge_count = %d (%d is max)\n",
@@ -67,12 +71,12 @@ purge_history(void)
 int
 insert_history_item(const gchar *uri, const gchar *title, time_t time)
 {
-	struct history		*h;
+	struct pagelist_entry		*h;
 
 	if (!(uri && strlen(uri) && title && strlen(title)))
 		return (1);
 
-	h = g_malloc(sizeof(struct history));
+	h = g_malloc(sizeof(struct pagelist_entry));
 	h->uri = g_strdup(uri);
 	h->title = g_strdup(title);
 	h->time = time;
@@ -161,7 +165,7 @@ save_global_history_to_disk(struct tab *t)
 {
 	char			file[PATH_MAX];
 	FILE			*f;
-	struct history		*h;
+	struct pagelist_entry		*h;
 
 	snprintf(file, sizeof file, "%s" PS "%s", work_dir, XT_HISTORY_FILE);
 
@@ -190,7 +194,7 @@ char *
 color_visited_helper(void)
 {
 	char			*d, *s = NULL, *t;
-	struct history		*h;
+	struct pagelist_entry		*h;
 
 	RB_FOREACH_REVERSE(h, history_list, &hl) {
 		if (s == NULL)

--- a/settings.c
+++ b/settings.c
@@ -75,6 +75,7 @@ int		show_scrollbars = XT_DS_SHOW_SCROLLBARS;
 int		show_statusbar = XT_DS_SHOW_STATUSBAR; /* vimperator style status bar */
 int		ctrl_click_focus = XT_DS_CTRL_CLICK_FOCUS; /* ctrl click gets focus */
 int		cookies_enabled = XT_DS_COOKIES_ENABLED; /* enable cookies */
+int		complete_uri_anywhere = XT_DS_COMPLETE_URI_ANYWHERE; /* complete uris by looking for matches anywhere within them */
 int		read_only_cookies = XT_DS_READ_ONLY_COOKIES; /* enable to not write cookies */
 int		enable_scripts = XT_DS_ENABLE_SCRIPTS;
 int		enable_plugins = XT_DS_ENABLE_PLUGINS;
@@ -159,6 +160,7 @@ int		set_cmd_font(char *);
 int		set_color_visited_uris(char *);
 int		set_cookie_policy_rt(char *);
 int		set_cookies_enabled(char *);
+int		set_complete_uri_anywhere(char *);
 int		set_ctrl_click_focus(char *);
 int		set_fancy_bar(char *);
 int		set_home(char *);
@@ -234,6 +236,7 @@ int		check_cmd_font(char **);
 int		check_color_visited_uris(char **);
 int		check_cookie_policy(char **);
 int		check_cookies_enabled(char **);
+int		check_complete_uri_anywhere(char **);
 int		check_ctrl_click_focus(char **);
 int		check_default_script(char **);
 int		check_default_zoom_level(char **);
@@ -515,6 +518,7 @@ struct settings		rs[] = {
 	{ "color_visited_uris",		XT_S_BOOL, 0,		&color_visited_uris , NULL, NULL, NULL, set_color_visited_uris, check_color_visited_uris, TT_COLOR_VISITED_URIS },
 	{ "cookie_policy",		XT_S_STR, 0, NULL, NULL,&s_cookie, NULL, set_cookie_policy_rt, check_cookie_policy, TT_COOKIE_POLICY },
 	{ "cookies_enabled",		XT_S_BOOL, 0,		&cookies_enabled, NULL, NULL, NULL, set_cookies_enabled, check_cookies_enabled, TT_COOKIES_ENABLED },
+	{ "complete_uri_anywhere",	XT_S_BOOL, 0,		&complete_uri_anywhere, NULL, NULL, NULL, set_complete_uri_anywhere, check_complete_uri_anywhere, TT_COMPLETE_URI_ANYWHERE },
 	{ "ctrl_click_focus",		XT_S_BOOL, 0,		&ctrl_click_focus, NULL, NULL, NULL, set_ctrl_click_focus, check_ctrl_click_focus, TT_CTRL_CLICK_FOCUS },
 	{ "default_script",		XT_S_STR, 1, NULL, NULL,&s_default_script, NULL, set_default_script_rt, check_default_script, TT_DEFAULT_SCRIPT },
 	{ "default_zoom_level",		XT_S_DOUBLE, 0,		NULL, NULL, NULL, &default_zoom_level, set_default_zoom_level, check_default_zoom_level, TT_DEFAULT_ZOOM_LEVEL },
@@ -725,6 +729,31 @@ check_cookies_enabled(char **tt)
 	*tt = g_strdup_printf("Default: %s",
 	    XT_DS_COOKIES_ENABLED ? "Enabled" : "Disabled");
 	return (cookies_enabled != XT_DS_COOKIES_ENABLED);
+}
+
+int
+set_complete_uri_anywhere(char *value)
+{
+	int			tmp;
+	const char		*errstr;
+
+	if (value == NULL || strlen(value) == 0)
+		complete_uri_anywhere = XT_DS_COMPLETE_URI_ANYWHERE;
+	else {
+		tmp = strtonum(value, 0, 1, &errstr);
+		if (errstr)
+			return (-1);
+		complete_uri_anywhere = tmp;
+	}
+	return (0);
+}
+
+int
+check_complete_uri_anywhere(char **tt)
+{
+	*tt = g_strdup_printf("Default: %s",
+	    XT_DS_COMPLETE_URI_ANYWHERE ? "Enabled" : "Disabled");
+	return (complete_uri_anywhere != XT_DS_COMPLETE_URI_ANYWHERE);
 }
 
 int

--- a/xombrero.1
+++ b/xombrero.1
@@ -1162,6 +1162,9 @@ beginning and end of the regex so that, for example,
 would not match not-moo.com.
 .It Cm cookies_enabled
 Enable cookies.
+.It Cm complete_uri_anywhere
+When completing URIs, match substrings anywhere in the target URI (rather
+than just the domain).
 .It Cm ctrl_click_focus
 Give focus in newly created tab instead of opening it in the background.
 .It Cm custom_uri

--- a/xombrero.c
+++ b/xombrero.c
@@ -208,7 +208,7 @@ GtkWidget		*tab_bar_box;
 GtkWidget		*arrow, *abtn;
 GdkEvent		*fevent = NULL;
 struct tab_list		tabs;
-struct history_list	hl;
+struct pagelist_entry	hl;
 int			hl_purge_count = 0;
 struct session_list	sessions;
 struct wl_list		c_wl;
@@ -689,7 +689,7 @@ int			download_rb_cmp(struct download *, struct download *);
 gboolean		cmd_execute(struct tab *t, char *str);
 
 int
-history_rb_cmp(struct history *h1, struct history *h2)
+history_rb_cmp(struct pagelist_entry *h1, struct pagelist_entry *h2)
 {
 	return (strcmp(h1->uri, h2->uri));
 }
@@ -4150,7 +4150,7 @@ void
 notify_load_status_cb(WebKitWebView* wview, GParamSpec* pspec, struct tab *t)
 {
 	const gchar		*uri = NULL;
-	struct history		*h, find;
+	struct pagelist_entry		*h, find;
 	struct karg		a;
 #if !GTK_CHECK_VERSION(3, 0, 0)
 	gchar			*text, *base;
@@ -6168,7 +6168,7 @@ void
 cmd_getlist(int id, char *key)
 {
 	int			i,  dep, c = 0;
-	struct history		*h;
+	struct pagelist_entry		*h;
 	struct session		*s;
 
 	if (key == NULL)

--- a/xombrero.c
+++ b/xombrero.c
@@ -6143,13 +6143,17 @@ match_uri(const gchar *uri, const gchar *key) {
 	if (!strncmp(key, uri, len))
 		match = TRUE;
 	else {
-		voffset = strstr(uri, "/") + 2;
-		if (!strncmp(key, voffset, len))
-			match = TRUE;
-		else if (g_str_has_prefix(voffset, "www.")) {
+		if (complete_uri_anywhere) {
+			match = !! strstr(uri, key);
+		} else {
+		  voffset = strstr(uri, "/") + 2;
+		  if (!strncmp(key, voffset, len))
+			  match = TRUE;
+		  else if (g_str_has_prefix(voffset, "www.")) {
 			voffset = voffset + strlen("www.");
 			if (!strncmp(key, voffset, len))
 				match = TRUE;
+			}
 		}
 	}
 

--- a/xombrero.c
+++ b/xombrero.c
@@ -208,7 +208,7 @@ GtkWidget		*tab_bar_box;
 GtkWidget		*arrow, *abtn;
 GdkEvent		*fevent = NULL;
 struct tab_list		tabs;
-struct history_list	hl;
+struct pagelist		hl;
 int			hl_purge_count = 0;
 struct session_list	sessions;
 struct wl_list		c_wl;
@@ -689,11 +689,11 @@ int			download_rb_cmp(struct download *, struct download *);
 gboolean		cmd_execute(struct tab *t, char *str);
 
 int
-history_rb_cmp(struct pagelist_entry *h1, struct pagelist_entry *h2)
+pagelist_rb_cmp(struct pagelist_entry *h1, struct pagelist_entry *h2)
 {
 	return (strcmp(h1->uri, h2->uri));
 }
-RB_GENERATE(history_list, pagelist_entry, entry, history_rb_cmp);
+RB_GENERATE(pagelist, pagelist_entry, entry, pagelist_rb_cmp);
 
 int
 download_rb_cmp(struct download *e1, struct download *e2)
@@ -4285,7 +4285,7 @@ notify_load_status_cb(WebKitWebView* wview, GParamSpec* pspec, struct tab *t)
 		    !strncmp(uri, "https://", strlen("https://")) ||
 		    !strncmp(uri, "file://", strlen("file://"))) {
 			find.uri = (gchar *)uri;
-			h = RB_FIND(history_list, &hl, &find);
+			h = RB_FIND(pagelist, &hl, &find);
 			if (!h)
 				insert_history_item(uri,
 				    get_title(t, FALSE), time(NULL));
@@ -6176,7 +6176,7 @@ cmd_getlist(int id, char *key)
 
 	if (id >= 0) {
 		if (cmds[id].type & XT_URLARG) {
-			RB_FOREACH_REVERSE(h, history_list, &hl)
+			RB_FOREACH_REVERSE(h, pagelist, &hl)
 				if (match_uri(h->uri, key)) {
 					cmd_status.list[c] = (char *)h->uri;
 					if (++c > 255)

--- a/xombrero.c
+++ b/xombrero.c
@@ -208,7 +208,7 @@ GtkWidget		*tab_bar_box;
 GtkWidget		*arrow, *abtn;
 GdkEvent		*fevent = NULL;
 struct tab_list		tabs;
-struct pagelist_entry	hl;
+struct history_list	hl;
 int			hl_purge_count = 0;
 struct session_list	sessions;
 struct wl_list		c_wl;
@@ -693,7 +693,7 @@ history_rb_cmp(struct pagelist_entry *h1, struct pagelist_entry *h2)
 {
 	return (strcmp(h1->uri, h2->uri));
 }
-RB_GENERATE(history_list, history, entry, history_rb_cmp);
+RB_GENERATE(history_list, pagelist_entry, entry, history_rb_cmp);
 
 int
 download_rb_cmp(struct download *e1, struct download *e2)

--- a/xombrero.c
+++ b/xombrero.c
@@ -6177,6 +6177,21 @@ cmd_getlist(int id, char *key)
 
 	if (id >= 0) {
 		if (cmds[id].type & XT_URLARG) {
+			/* It'd be great if we could use the 
+			completion_model here.  Alas, GtkTreeModel apparently
+			has no API to access the char * in there; it seems
+			you only can get copies from there, which would
+			then have to be freed by the calling function.
+			Hence, we manually to through history and favourites
+			for now. */
+
+			RB_FOREACH_REVERSE(h, pagelist, &favs)
+				if (match_uri(h->uri, key)) {
+					cmd_status.list[c] = (char *)h->uri;
+					if (++c > 255)
+						break;
+				}
+
 			RB_FOREACH_REVERSE(h, pagelist, &hl)
 				if (match_uri(h->uri, key)) {
 					cmd_status.list[c] = (char *)h->uri;
@@ -8860,9 +8875,6 @@ main(int argc, char **argv)
 	if (enable_strict_transport)
 		strict_transport_init();
 
-	/* pull favorites into memory */
-	restore_favorites();
-
 	/* uri completion */
 	completion_model = gtk_list_store_new(1, G_TYPE_STRING);
 
@@ -8878,6 +8890,14 @@ main(int argc, char **argv)
 
 	if (save_global_history)
 		restore_global_history();
+
+	/* pull favorites into memory */
+	if (!restore_favorites()) {
+		struct pagelist_entry	*item;
+		RB_FOREACH(item, pagelist, &favs) {
+			completion_add_uri(item->uri);
+		}
+	}
 
 	/* restore session list */
 	restore_sessions_list();

--- a/xombrero.c
+++ b/xombrero.c
@@ -210,6 +210,7 @@ GdkEvent		*fevent = NULL;
 struct tab_list		tabs;
 struct pagelist		hl;
 int			hl_purge_count = 0;
+struct pagelist		favs;
 struct session_list	sessions;
 struct wl_list		c_wl;
 struct wl_list		js_wl;
@@ -8858,6 +8859,9 @@ main(int argc, char **argv)
 
 	if (enable_strict_transport)
 		strict_transport_init();
+
+	/* pull favorites into memory */
+	restore_favorites();
 
 	/* uri completion */
 	completion_model = gtk_list_store_new(1, G_TYPE_STRING);

--- a/xombrero.h
+++ b/xombrero.h
@@ -432,7 +432,15 @@ int			restore_global_history(void);
 char			*color_visited_helper(void);
 int			color_visited(struct tab *t, char *visited);
 int 			remove_pagelist_entry_by_count(struct pagelist *list, int count);
+void 			remove_pagelist_entry_by_uri(struct pagelist *list, const gchar *uri);
 void 			remove_pagelist_entry(struct pagelist *list, struct pagelist_entry *item);
+int			load_pagelist_from_disk(struct pagelist *list, char *file_name);
+int			save_pagelist_to_disk(struct pagelist *list, char *file_name);
+int			insert_pagelist_entry(struct pagelist *list, const gchar *uri, const gchar *title, time_t time);
+void			empty_pagelist(struct pagelist *list);
+
+
+
 
 /* completion */
 void			completion_add(struct tab *);
@@ -520,6 +528,7 @@ int			xtp_page_sl(struct tab *, struct karg *);
 int			xtp_page_sv(struct tab *, struct karg *);
 int			parse_xtp_url(struct tab *, const char *);
 int			add_favorite(struct tab *, struct karg *);
+int			restore_favorites(void);
 void			update_favorite_tabs(struct tab *);
 void			update_history_tabs(struct tab *);
 void			update_download_tabs(struct tab *);
@@ -990,7 +999,8 @@ extern void	(*_soup_cookie_jar_add_cookie)(SoupCookieJar *, SoupCookie *);
 extern void	(*_soup_cookie_jar_delete_cookie)(SoupCookieJar *,
 		    SoupCookie *);
 
-extern struct pagelist	hl;
+extern struct pagelist		hl;
+extern struct pagelist		favs;
 extern int			hl_purge_count;
 extern struct download_list	downloads;
 extern struct tab_list		tabs;

--- a/xombrero.h
+++ b/xombrero.h
@@ -326,13 +326,13 @@ RB_HEAD(download_list, download);
 RB_PROTOTYPE(download_list, download, entry, download_rb_cmp);
 
 struct pagelist_entry {
-	RB_ENTRY(history)	entry;
-	gchar			*uri;
-	gchar			*title;
-	time_t			time; /* When the item was added. */
+	RB_ENTRY(pagelist_entry)	entry;
+	gchar				*uri;
+	gchar				*title;
+	time_t	 			time; /* When the item was added. */
 };
-RB_HEAD(history_list, history);
-RB_PROTOTYPE(history_list, history, entry, history_rb_cmp);
+RB_HEAD(history_list, pagelist_entry);
+RB_PROTOTYPE(history_list, pagelist_entry, entry, history_rb_cmp);
 
 #define XT_STS_FLAGS_INCLUDE_SUBDOMAINS		(1)
 #define XT_STS_FLAGS_EXPAND			(2)

--- a/xombrero.h
+++ b/xombrero.h
@@ -331,8 +331,8 @@ struct pagelist_entry {
 	gchar				*title;
 	time_t	 			time; /* When the item was added. */
 };
-RB_HEAD(history_list, pagelist_entry);
-RB_PROTOTYPE(history_list, pagelist_entry, entry, history_rb_cmp);
+RB_HEAD(pagelist, pagelist_entry);
+RB_PROTOTYPE(pagelist, pagelist_entry, entry, pagelist_rb_cmp);
 
 #define XT_STS_FLAGS_INCLUDE_SUBDOMAINS		(1)
 #define XT_STS_FLAGS_EXPAND			(2)
@@ -425,12 +425,14 @@ void	setup_cookies(void);
 void	soup_cookie_jar_add_cookie(SoupCookieJar *, SoupCookie *);
 void	soup_cookie_jar_delete_cookie(SoupCookieJar *, SoupCookie *);
 
-/* history */
+/* page lists */
 int			insert_history_item(const gchar *uri, const gchar *title, time_t time);
 int			save_global_history_to_disk(struct tab *t);
 int			restore_global_history(void);
 char			*color_visited_helper(void);
 int			color_visited(struct tab *t, char *visited);
+int 			remove_pagelist_entry_by_count(struct pagelist *list, int count);
+void 			remove_pagelist_entry(struct pagelist *list, struct pagelist_entry *item);
 
 /* completion */
 void			completion_add(struct tab *);
@@ -988,7 +990,7 @@ extern void	(*_soup_cookie_jar_add_cookie)(SoupCookieJar *, SoupCookie *);
 extern void	(*_soup_cookie_jar_delete_cookie)(SoupCookieJar *,
 		    SoupCookie *);
 
-extern struct history_list	hl;
+extern struct pagelist	hl;
 extern int			hl_purge_count;
 extern struct download_list	downloads;
 extern struct tab_list		tabs;

--- a/xombrero.h
+++ b/xombrero.h
@@ -395,6 +395,11 @@ RB_PROTOTYPE(domain_id_list, domain_id, entry, domain_id_rb_cmp);
 #define XT_HTTP_ACCEPT_FILE	("http-accept-headers")
 #define XT_RESERVED_CHARS	"$&+,/:;=?@ \"<>#%%{}|^~[]`"
 
+#define XT_PAGELIST_MAGIC	"# Xombrero Pagelist"
+#define XT_PAGELIST_DATEFMT	"%Y-%m-%dT%H:%M:%S"
+/* The length for a date formatted with XT_PAGELIST_DATEMFT */
+#define XT_PAGELIST_DATELENGTH	20
+
 int			run_script(struct tab *, char *);
 void			js_autorun(struct tab *);
 void			xt_icon_from_file(struct tab *, char *);

--- a/xombrero.h
+++ b/xombrero.h
@@ -325,7 +325,7 @@ struct download {
 RB_HEAD(download_list, download);
 RB_PROTOTYPE(download_list, download, entry, download_rb_cmp);
 
-struct history {
+struct pagelist_entry {
 	RB_ENTRY(history)	entry;
 	gchar			*uri;
 	gchar			*title;

--- a/xombrero.h
+++ b/xombrero.h
@@ -658,6 +658,7 @@ int		command_mode(struct tab *, struct karg *);
 #define XT_DS_SHOW_STATUSBAR	(0)
 #define XT_DS_CTRL_CLICK_FOCUS	(0)
 #define XT_DS_COOKIES_ENABLED	(1)
+#define XT_DS_COMPLETE_URI_ANYWHERE	(0)
 #define XT_DS_READ_ONLY_COOKIES	(0)
 #define XT_DS_ENABLE_SCRIPTS	(1)
 #define XT_DS_ENABLE_PLUGINS	(1)
@@ -908,6 +909,7 @@ extern int	show_scrollbars;
 extern int	show_statusbar;
 extern int	ctrl_click_focus;
 extern int	cookies_enabled;
+extern int	complete_uri_anywhere;
 extern int	read_only_cookies;
 extern int	enable_cache;
 extern int	enable_scripts;


### PR DESCRIPTION
This PR supersedes  PR #89. It fixes it in two points:

* I've cleaned it up (though I just notice I've cherry-picked the same commit twice -- I hope you don't mind)
* It fixes the problem that -- as current xombrero history -- it wouldn't work in non-English locales.

The main point in this pull request is to enable tab completion of items
in the list of favourites.

To do this, the first three commits make the existing code for handling the
history generic enough so it can be used for the favourites, too.

The next commit actually manages the favourites list in memory; this results in
a change in the favourite file's on-disk format. There was code for
heuristically deciding what's what, but see below.

Then (9def345),  the in-memory favourites are used to complete URIs,
which really is what (amost) all this is about; the new behaviour is
then made configurable in the following commit via the new config option
complete_uri_anywhere defaulting to false (current xombrero behaviour).
If you set it to 1, URI expansion will happen based on matches anywhere
in the URIs.

The current history format uses ctime in serialisation, but strptime with
locale-dependent input field descriptors in deseerialisation, which made it
break in non-English locales.  With this proposal, this breakage would
have extended to favourites, so I'm fixing it in the final commit.
Essentially, with it xombrero pagelists would then start with a magic
and have ISO-style dates. The loaders check for the magic and, in this
commit, fall back to the legacy parsers if they don't find it.

One drawback mentioned in #89 remains: As in current HEAD, there are
two sources of URL completion: The completion model from complete.h, and
the manual stuff in cmd_getlist.  The fact that completion\_add\_uri
didn't have an effect on completing "open" was really confusing to me.
Alas, I've not found an API to get to harmless char* to memory held
within a GtkTreeView, and, though I've not really investigated that, I
believe they can't sling around pointers to memory owned by them as it
could be freed essentially at any time. So, we'd have to teach
cmd_getlist to (conditionally?) free its stuff.  I'm not sure whether
that effort is worth it, and maybe it's even right to have two methods
because they're really doing different things (but then a comment in
completion.c would be of great public service).
